### PR TITLE
Fixed preview state file updating too early, and reuse file handle for writing state changes

### DIFF
--- a/src/main/java/me/voidxwalker/worldpreview/StateOutputHelper.java
+++ b/src/main/java/me/voidxwalker/worldpreview/StateOutputHelper.java
@@ -3,8 +3,8 @@ package me.voidxwalker.worldpreview;
 import org.apache.logging.log4j.Level;
 
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
@@ -20,6 +20,8 @@ public final class StateOutputHelper {
     public static int loadingProgress = 0;
     public static boolean titleHasEverLoaded = false;
     private static String lastOutput = "";
+
+    private static RandomAccessFile stateFile;
 
 
     private StateOutputHelper() {
@@ -44,8 +46,12 @@ public final class StateOutputHelper {
 
     private static void outputStateInternal(String string) {
         try {
-            // Java 11+ method
-            Files.write(OUT_PATH, string.getBytes(StandardCharsets.UTF_8));
+            if(stateFile == null){ // opening file only once is better for performance
+                stateFile = new RandomAccessFile(OUT_PATH.toString(), "rw");
+            }
+            stateFile.setLength(0); // clear existing file contents
+            stateFile.seek(0); // move pointer back to start of file
+            stateFile.write(string.getBytes(StandardCharsets.UTF_8));
             WorldPreview.log(Level.INFO, "WorldPreview State: " + string);
         } catch (IOException ignored) {
             WorldPreview.log(Level.ERROR, "Failed to write state output!");

--- a/src/main/java/me/voidxwalker/worldpreview/WorldPreview.java
+++ b/src/main/java/me/voidxwalker/worldpreview/WorldPreview.java
@@ -22,6 +22,7 @@ public class WorldPreview  implements ClientModInitializer {
    public static ClientPlayerEntity player;
    public static ClientWorld clientWord;
    public static boolean inPreview;
+   public static boolean renderingPreview;
    public static BlockPos spawnPos;
    public static int kill=0;
    public static int playerSpawn;

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/MinecraftClientMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/MinecraftClientMixin.java
@@ -144,4 +144,14 @@ public abstract class MinecraftClientMixin {
             StateOutputHelper.outputState("inworld,gamescreenopen");
         }
     }
+
+    @Inject(method = "render", at = @At(value = "INVOKE", target="Lnet/minecraft/client/util/Window;swapBuffers()V", shift = At.Shift.AFTER))
+    private void worldpreview_actuallyInPreview(boolean tick, CallbackInfo ci) {
+        if (WorldPreview.inPreview && !WorldPreview.renderingPreview) {
+            WorldPreview.renderingPreview = true;
+            StateOutputHelper.outputState("previewing," + StateOutputHelper.loadingProgress);
+            WorldPreview.log(Level.INFO, "Starting Preview at (" + WorldPreview.player.getX() + ", " + (double) Math.floor(WorldPreview.player.getY()) + ", " + WorldPreview.player.getZ() + ")");
+        }
+    }
+
 }

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/WorldGenerationProgressLoggerMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/WorldGenerationProgressLoggerMixin.java
@@ -18,7 +18,7 @@ public abstract class WorldGenerationProgressLoggerMixin {
     private void worldpreview_outputGenerationState(ChunkPos pos, ChunkStatus status, CallbackInfo info) {
         // Using the getProgressPercentage to recalculate is slightly unoptimized but prevents needing to do locals capture, making it easier to port this mixin.
         StateOutputHelper.loadingProgress = MathHelper.clamp(getProgressPercentage(), 0, 100);
-        StateOutputHelper.outputState((WorldPreview.inPreview ? "previewing," : "generating,") + StateOutputHelper.loadingProgress);
+        StateOutputHelper.outputState((WorldPreview.renderingPreview ? "previewing," : "generating,") + StateOutputHelper.loadingProgress);
     }
 
     @Shadow

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/LevelLoadingScreenMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/LevelLoadingScreenMixin.java
@@ -89,8 +89,6 @@ public abstract class LevelLoadingScreenMixin extends Screen {
                     WorldPreview.camera.update(WorldPreview.world, WorldPreview.player, this.client.options.perspective > 0, this.client.options.perspective == 2, 0.2F);
                     WorldPreview.player.refreshPositionAndAngles(WorldPreview.player.getX(), WorldPreview.player.getY() - 1.5, WorldPreview.player.getZ(), 0.0F, 0.0F);
                     WorldPreview.inPreview=true;
-                    StateOutputHelper.outputState("previewing," + StateOutputHelper.loadingProgress);
-                    WorldPreview.log(Level.INFO,"Starting Preview at ("+ WorldPreview.player.getX() + ", "+(double)Math.floor(WorldPreview.player.getY())+ ", "+ WorldPreview.player.getZ()+")");
                 }
                 MatrixStack matrixStack = new MatrixStack();
                 matrixStack.peek().getModel().multiply(this.worldpreview_getBasicProjectionMatrix());

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/server/MinecraftServerMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/server/MinecraftServerMixin.java
@@ -137,6 +137,7 @@ public abstract class MinecraftServerMixin  extends ReentrantThreadExecutor<Serv
     @Inject(method="runServer",at=@At(value="INVOKE",target="Lnet/minecraft/server/MinecraftServer;setupServer()Z",shift = At.Shift.AFTER), cancellable = true)
     public void worldpreview_kill2(CallbackInfo ci){
         WorldPreview.inPreview=false;
+        WorldPreview.renderingPreview=false;
         LockSupport.unpark(((MinecraftClientMixin)MinecraftClient.getInstance()).invokeGetThread());
         if(WorldPreview.kill==1){
             ci.cancel();


### PR DESCRIPTION
WorldPreview.inPreview is set to true before a frame is actually rendered on the screen (the time difference can be up to a couple of seconds with client lag), which caused issues for macros unhiding dirt covers as soon as the preview state was logged
This change only prints the log and preview state once the game has called swapBuffers to actually push the preview frame on screen

Also only opens the state file once, instead of opening+closing a file on every state change